### PR TITLE
EntityTooLarge error

### DIFF
--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -59,9 +59,6 @@ func setupRouter() *echo.Echo {
 
 func setupRouterV2() *echo.Echo {
 	e := echo.New()
-	e.Use(
-		middleware.BodyLimit(maxRequestBodyBytes),
-	)
 	// Make a deep copy of the routes array with handlers.
 	adminMiddleware := []echo.MiddlewareFunc{
 		middlewares.MakeAuth(TokenHeader, []string{""}),
@@ -115,6 +112,10 @@ func TestLargeKeyRegister(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	e := setupRouterV2()
+	// set request body limit
+	e.Use(
+		middleware.BodyLimit(maxRequestBodyBytes),
+	)
 	go e.Start(":9999")
 
 	// TODO: Make sure this fails without the change

--- a/daemon/algod/api/server/router_test.go
+++ b/daemon/algod/api/server/router_test.go
@@ -23,12 +23,18 @@ import (
 	"testing"
 
 	"github.com/algorand/go-algorand/daemon/algod/api/server/lib"
+	"github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares"
 	"github.com/algorand/go-algorand/daemon/algod/api/server/v1/routes"
-	"github.com/labstack/echo/v4"
-	"github.com/stretchr/testify/assert"
-
+	v2 "github.com/algorand/go-algorand/daemon/algod/api/server/v2"
+	npprivate "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/nonparticipating/private"
+	nppublic "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/nonparticipating/public"
+	pprivate "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/participating/private"
+	ppublic "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/participating/public"
 	"github.com/algorand/go-algorand/logging"
 	"github.com/algorand/go-algorand/test/partitiontest"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/stretchr/testify/assert"
 )
 
 func setupRouter() *echo.Echo {
@@ -47,6 +53,28 @@ func setupRouter() *echo.Echo {
 	reqCtx := lib.ReqContext{Log: logging.NewLogger()}
 	// Registering v1 routes
 	registerHandlers(e, apiV1Tag, v1RoutesCopy, reqCtx)
+
+	return e
+}
+
+func setupRouterV2() *echo.Echo {
+	e := echo.New()
+	e.Use(
+		middleware.BodyLimit(maxRequestBodyBytes),
+	)
+	// Make a deep copy of the routes array with handlers.
+	adminMiddleware := []echo.MiddlewareFunc{
+		middlewares.MakeAuth(TokenHeader, []string{""}),
+	}
+	publicMiddleware := []echo.MiddlewareFunc{
+		middleware.BodyLimit(maxRequestBodyBytes),
+		middlewares.MakeAuth(TokenHeader, []string{""}),
+	}
+	v2Handler := v2.Handlers{}
+	nppublic.RegisterHandlers(e, &v2Handler, publicMiddleware...)
+	npprivate.RegisterHandlers(e, &v2Handler, adminMiddleware...)
+	ppublic.RegisterHandlers(e, &v2Handler, publicMiddleware...)
+	pprivate.RegisterHandlers(e, &v2Handler, adminMiddleware...)
 
 	return e
 }
@@ -86,7 +114,7 @@ func TestLargeKeyRegister(t *testing.T) {
 	t.Parallel()
 
 	rec := httptest.NewRecorder()
-	e := setupRouter()
+	e := setupRouterV2()
 	go e.Start(":9999")
 
 	// TODO: Make sure this fails without the change
@@ -94,8 +122,11 @@ func TestLargeKeyRegister(t *testing.T) {
 	stringReader := strings.NewReader(strings.Repeat("a", 50_000_000))
 	req, err := http.NewRequest(http.MethodPost, "localhost:9999/v2/participation", stringReader)
 	assert.NoError(t, err)
-
 	e.ServeHTTP(rec, req)
+	// this assertion fails
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// this assertion passes
+	//assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
 	fmt.Println(rec.Body.String())
 }
 

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -2261,7 +2261,7 @@ func TestLargeKeyRegister(t *testing.T) {
 	ppublic.RegisterHandlers(s, &handler, publicMiddleware...)
 	pprivate.RegisterHandlers(s, &handler, adminMiddleware...)
 	go s.Start(":9998")
-	req, err = http.NewRequest(http.MethodPost, "http://localhost:9999/v2/participation", stringReader)
+	req, err = http.NewRequest(http.MethodPost, "http://localhost:9998/v2/participation", stringReader)
 	assert.NoError(t, err)
 	s.ServeHTTP(rec2, req)
 	assert.Equal(t, http.StatusOK, rec2.Code)

--- a/daemon/algod/api/server/v2/test/handlers_test.go
+++ b/daemon/algod/api/server/v2/test/handlers_test.go
@@ -30,10 +30,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/algorand/go-algorand/daemon/algod/api/server/lib/middlewares"
+	npprivate "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/nonparticipating/private"
+	nppublic "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/nonparticipating/public"
+	pprivate "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/participating/private"
+	ppublic "github.com/algorand/go-algorand/daemon/algod/api/server/v2/generated/participating/public"
 	"github.com/algorand/go-algorand/ledger/eval"
 	"github.com/algorand/go-algorand/ledger/ledgercore"
-
 	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -2202,4 +2207,63 @@ func TestDeltasForTxnGroup(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.Equal(t, 501, rec.Code)
+}
+
+func TestLargeKeyRegister(t *testing.T) {
+	partitiontest.PartitionTest(t)
+	t.Parallel()
+
+	numAccounts := 1
+	numTransactions := 1
+	offlineAccounts := true
+	mockLedger, _, _, _, _ := testingenv(t, numAccounts, numTransactions, offlineAccounts)
+	mockNode := makeMockNode(mockLedger, t.Name(), nil, cannedStatusReportGolden, false)
+	dummyShutdownChan := make(chan struct{})
+	handler := v2.Handlers{
+		Node:     mockNode,
+		Log:      logging.Base(),
+		Shutdown: dummyShutdownChan,
+	}
+
+	rec := httptest.NewRecorder()
+	e := echo.New()
+	// set request body limit
+	e.Use(
+		middleware.BodyLimit("10MB"),
+	)
+
+	// Registering v2 routes
+	adminMiddleware := []echo.MiddlewareFunc{
+		middlewares.MakeAuth("X-Algo-API-Token", []string{""}),
+	}
+	publicMiddleware := []echo.MiddlewareFunc{
+		middleware.BodyLimit("10MB"),
+		middlewares.MakeAuth("X-Algo-API-Token", []string{""}),
+	}
+	nppublic.RegisterHandlers(e, &handler, publicMiddleware...)
+	npprivate.RegisterHandlers(e, &handler, adminMiddleware...)
+	ppublic.RegisterHandlers(e, &handler, publicMiddleware...)
+	pprivate.RegisterHandlers(e, &handler, adminMiddleware...)
+
+	go e.Start(":9999")
+	stringReader := strings.NewReader(strings.Repeat("a", 50_000_000))
+	req, err := http.NewRequest(http.MethodPost, "http://localhost:9999/v2/participation", stringReader)
+	assert.NoError(t, err)
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, rec.Code)
+	e.Close()
+
+	//start a new server without request body limit
+	rec2 := httptest.NewRecorder()
+	s := echo.New()
+	nppublic.RegisterHandlers(s, &handler, publicMiddleware...)
+	npprivate.RegisterHandlers(s, &handler, adminMiddleware...)
+	ppublic.RegisterHandlers(s, &handler, publicMiddleware...)
+	pprivate.RegisterHandlers(s, &handler, adminMiddleware...)
+	go s.Start(":9998")
+	req, err = http.NewRequest(http.MethodPost, "http://localhost:9999/v2/participation", stringReader)
+	assert.NoError(t, err)
+	s.ServeHTTP(rec2, req)
+	assert.Equal(t, http.StatusOK, rec2.Code)
+	s.Close()
 }

--- a/daemon/algod/api/server/v2/test/helpers.go
+++ b/daemon/algod/api/server/v2/test/helpers.go
@@ -103,7 +103,7 @@ type mockNode struct {
 }
 
 func (m *mockNode) InstallParticipationKey(partKeyBinary []byte) (account.ParticipationID, error) {
-	panic("implement me")
+	return account.ParticipationID{}, nil
 }
 
 func (m *mockNode) ListParticipationKeys() ([]account.ParticipationRecord, error) {


### PR DESCRIPTION
a unit test fails with EntityTooLarge error.